### PR TITLE
C examples fixes

### DIFF
--- a/resources/examples/src/test_buffer_mep.c
+++ b/resources/examples/src/test_buffer_mep.c
@@ -18,55 +18,70 @@ unsigned int buffer_len = 12;
 
 
 int main (int argc, char ** argv) {
+  bfd                     *bfdFile;
+  asection                *section;
   disassembler_ftype      disassemble;
   struct disassemble_info info;
   unsigned long           count, pc;
 
-  /* Construct a specific disassembler */
+  /* Open /dev/null as a binary target with libbfd */
+  bfdFile = bfd_openr ("/dev/null", "binary");
+  if (bfdFile == NULL) {
+    printf ("Error [%x]: %s\n", bfd_get_error (),
+                                bfd_errmsg (bfd_get_error ()));
+    return EXIT_FAILURE;
+  }
+
+  /* Check the file format */
+  if (!bfd_check_format (bfdFile, bfd_object)) {
+    printf ("Error [%x]: %s\n", bfd_get_error (),
+                                bfd_errmsg (bfd_get_error ()));
+    return EXIT_FAILURE;
+  }
+
+  /* Retrieve the ELF .data code section */
+  section = bfd_get_section_by_name (bfdFile, ".data");
+  if (section == NULL) {
+    printf ("Error accessing .text section\n");
+    return EXIT_FAILURE;
+  }
+
+  /* Configure a MeP disassembler */
   enum bfd_architecture arch = bfd_arch_mep;
   bfd_boolean big_endian = BFD_ENDIAN_BIG;
   unsigned long mach = bfd_mach_mep;
-  disassemble = disassembler (arch, big_endian, mach, NULL);
+  bfd_default_set_arch_mach(bfdFile, arch, mach);
+  disassemble = disassembler (bfd_get_arch (bfdFile), bfd_big_endian (bfdFile),
+                              bfd_get_mach (bfdFile), bfdFile);
   if( disassemble == NULL) {
-    printf( "Error creating disassembler\n" );
+    printf ("Error creating disassembler\n" );
     return EXIT_FAILURE;
   }
 
   /* Construct and configure the disassembler_info structure */
   init_disassemble_info (&info, stdout, (fprintf_ftype) fprintf);
-  info.arch = arch;
-  info.mach = mach;
+  info.arch = bfd_get_arch (bfdFile);
+  info.mach = bfd_get_mach (bfdFile);
+  info.section = section;
+
+  /* Configure buffer information */
+  section->vma = 0xC00000; // memory offset
   info.read_memory_func = buffer_read_memory; // builtin
-
-  // Values dumped thanks to GDB
-  info.octets_per_byte = 1;
-  info.skip_zeroes = 256;
-  info.skip_zeroes_at_end = 0;
-  info.insn_type = dis_noninsn;
-  info.target = 0;
-  info.target2 = 0;
-  info.stop_vma = 0;
-  info.flags = DISASSEMBLE_DATA;
-
-  asection section;
-  section.vma = 0xC00000; // memory offset
-  section.flags = 0; // important: grep VLIW in opcodes/dis-mep.c to know why!
-  info.section = &section;
-
   info.buffer_length = buffer_len;
   info.buffer = (bfd_byte*) &buffer;
-  info.buffer_vma = section.vma;
+  info.buffer_vma = section->vma;
 
+  /* Initialize the disassembler_info structure */
   disassemble_init_for_target (&info);
 
   /* Diassemble instructions */
-  pc = section.vma;
+  pc = section->vma;
   for (int i=0; i < 4; i++) {
-    printf("Address: 0x%x\n  ", pc);
-    count = disassemble(pc, &info);
+    printf ("Address: 0x%lx\n  ", pc);
+    count = disassemble (pc, &info);
     pc += count;
-    printf("\n====\n");
-    fflush(stdout);
+    printf ("\n====\n");
+    fflush (stdout);
   }
 
   return EXIT_SUCCESS;

--- a/resources/examples/src/test_buffer_x86_64.c
+++ b/resources/examples/src/test_buffer_x86_64.c
@@ -14,7 +14,7 @@ int buffer_len = 4;
 int buffer_ptr = 0;
 
 int copy_buffer(bfd_vma memaddr, bfd_byte *myaddr, unsigned int length,
-		struct disassemble_info *dinfo) {
+  struct disassemble_info *dinfo) {
   // Copy our buffer to binutils
   
   if (length > buffer_len)
@@ -26,7 +26,7 @@ int copy_buffer(bfd_vma memaddr, bfd_byte *myaddr, unsigned int length,
   return 0;
 }
 
-int main(int argc, char ** argv) {
+int main(int argc, char** argv) {
   disassembler_ftype      disassemble;
   struct disassemble_info info;
   unsigned long           count, pc;

--- a/resources/examples/src/test_buffer_x86_64.c
+++ b/resources/examples/src/test_buffer_x86_64.c
@@ -52,7 +52,7 @@ int main(int argc, char ** argv) {
   /* Disassemble instruction from the buffer */
   pc = 0;
   for (int i=0; i < 3; i++) {
-    printf ("Address: 0x%x\n", pc);
+    printf ("Address: 0x%lx\n", pc);
     count = disassemble (pc, &info);
     pc += count;
     printf ("\nType: 0x%x\n", info.insn_type);


### PR DESCRIPTION
The MeP C example was segfaulting. This PR uses a new logic to initialize the structures.